### PR TITLE
fix build for makefile /file/libmpeg/ps/Makefile

### DIFF
--- a/file/libh26x/h264demux.cpp
+++ b/file/libh26x/h264demux.cpp
@@ -163,7 +163,7 @@ int _GetFrame(void* handle, const char **frame, int *length)
         desc->config.spslen = desc->sps.size();
 
         SPS stuSps;
-        h264dec_seq_parameter_set((void*)desc->sps.data()+5, desc->sps.size()-5, &stuSps);
+        h264dec_seq_parameter_set((void*)(desc->sps.data()+5), desc->sps.size()-5, &stuSps);
         desc->config.width = (stuSps.pic_width_in_mbs_minus1+1)*16;
         desc->config.height = (stuSps.pic_height_in_map_units_minus1+1)*16;
 

--- a/file/testaac/h264demux.cpp
+++ b/file/testaac/h264demux.cpp
@@ -157,7 +157,7 @@ int _GetFrame(void* handle, const char **frame, int *length)
         desc->config.spslen = desc->sps.size();
 
         SPS stuSps;
-        h264dec_seq_parameter_set((void*)desc->sps.data()+5, desc->sps.size()-5, &stuSps);
+        h264dec_seq_parameter_set((void*)(desc->sps.data()+5), desc->sps.size()-5, &stuSps);
         desc->config.width = (stuSps.pic_width_in_mbs_minus1+1)*16;
         desc->config.height = (stuSps.pic_height_in_map_units_minus1+1)*16;
 


### PR DESCRIPTION

RT.

```bash
make
g++ -g -I../../libaac -I../../libh26x   -c -o ../../libh26x/h264demux.o ../../libh26x/h264demux.cpp
../../libh26x/h264demux.cpp:166:58: error: arithmetic on a pointer to void
        h264dec_seq_parameter_set((void*)desc->sps.data()+5, desc->sps.size()-5, &stuSps);
```